### PR TITLE
make optional provider config fields optional

### DIFF
--- a/examples/providerconfig/secret.yaml.tmpl
+++ b/examples/providerconfig/secret.yaml.tmpl
@@ -8,5 +8,8 @@ stringData:
   credentials: |
     {
       "client_id": "PlaceYour32CharacterClientIDHere",
-      "client_secret": "t0ps3cr3t11"
+      "client_secret": "t0ps3cr3t11",
+      "request_timeout": "30",
+      "response_max_page_size": "100",
+      "endpoint": "https://api.equinix.com"
     }

--- a/internal/clients/equinix.go
+++ b/internal/clients/equinix.go
@@ -90,8 +90,14 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 
 		// set provider configuration
 		ps.Configuration = map[string]interface{}{}
-		for _, key := range []string{keyEndpoint, keyRequestTimeout, keyResponseMaxPageSize} {
-			ps.Configuration[key] = equinixCreds[key]
+		for _, key := range []string{
+			keyEndpoint,
+			keyRequestTimeout,
+			keyResponseMaxPageSize,
+		} {
+			if equinixCreds[key] != "" {
+				ps.Configuration[key] = equinixCreds[key]
+			}
 		}
 		// set environment variables for sensitive provider configuration
 		ps.Env = []string{


### PR DESCRIPTION
The provider offers optional configuration parameters that needed to be supplied. This made configuration less obvious because these optional parameters were not included in the same secret.

The sample secret now includes these optional configuration parameters.

The optional parameters will not be sent to the provider when they are unset. This prevents the error messages one would get from have an empty URL, or a 0 response size setting, or a 0 request timeout setting.
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
