### PR TITLE
fix the invalid / templated package path used during install

### DIFF
--- a/package/crossplane.yaml
+++ b/package/crossplane.yaml
@@ -2,6 +2,18 @@ apiVersion: meta.pkg.crossplane.io/v1alpha1
 kind: Provider
 metadata:
   name: provider-jet-equinix
-spec:
-  controller:
-    image: DOCKER_REGISTRY/provider-jet-equinix-controller:VERSION
+  annotations:
+    meta.crossplane.io/maintainer: Crossplane Maintainers <info@crossplane.io>
+    meta.crossplane.io/source: github.com/crossplane-contrib/provider-jet-equinix
+    meta.crossplane.io/license: Apache-2.0
+    meta.crossplane.io/description: |
+      The Equinix Crossplane provider adds support for
+      managing Equinix resources in Kubernetes.
+
+    meta.crossplane.io/readme: |
+      `provider-jet-equinix` is the Crossplane infrastructure provider for the [Equinix](https://equinix.com/).
+
+      If you encounter an issue please reach out on
+      [slack.crossplane.io](https://slack.crossplane.io) and create an issue in
+      the [crossplane/provider-jet-equinix](https://github.com/crossplane/provider-jet-equinix)
+      repo.


### PR DESCRIPTION

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

fix the invalid / templated package path used during install


Current deploys end up with an invalid image name:
```
    image: DOCKER_REGISTRY/provider-jet-equinix-controller:VERSION
```
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #

I have:

- [ ] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
